### PR TITLE
Handle electronic components with the same name

### DIFF
--- a/pages/electronics-library.tsx
+++ b/pages/electronics-library.tsx
@@ -138,6 +138,7 @@ const Home = ({
 
   const [filteredComponents, setFilteredComponents] =
     useState<IElectronicsComponent[]>(electronicComponents);
+
   const filterComponents = () => {
     let componentList: IElectronicsComponent[] = electronicComponents;
     if (searchCategoryTags[0] !== CategoryTags.ShowAll) {
@@ -169,8 +170,6 @@ const Home = ({
 
   useEffect(() => {
     filterComponents();
-    buildResultsHeader(searchField, searchCategoryTags);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchCategoryTags, searchField]);
 
   return (
@@ -249,7 +248,7 @@ const Home = ({
       <div className={styles.electronicsContainer}>
         {filteredComponents.map((item: any) => (
           <div
-            key={item.name}
+            key={item.name + item.shortDescription.substring(0, 30)}
             className={styles.electronicsItem}
             onClick={() => {
               setShowOverlay(true);


### PR DESCRIPTION
Due to the fact we had two different electronic components named `Presence/Motion Sensor` and we use the name as the key for the component, we ended up not properly cleaning up the list of components when toggle between `Sensors` and some other category.

By adding a brief snippet of the description to the key, we can handle if two different components have the same name.

I also removed an unnecessary function call, which allowed me to remove a comment for ignoring eslint.