### PR TITLE
ESLint sort imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,8 @@ module.exports = {
   plugins: [
     "react",
     "@typescript-eslint",
-    "import"
+    "import",
+    "simple-import-sort"
   ],
   rules: {
     "react/prop-types": "off",
@@ -38,11 +39,30 @@ module.exports = {
     "import/no-unresolved": "off",
     "no-case-declarations": "off",
     "@typescript-eslint/no-use-before-define": "off",
-
     "object-shorthand": [
       "error",
       "always"
     ],
+    "simple-import-sort/imports": [
+      "error",
+      {
+        "groups": [
+          // Packages `react` related packages come first.
+          ["^react", "^@?\\w"],
+          // Internal packages.
+          ["^(@|components)(/.*|$)"],
+          // Side effect imports.
+          ["^\\u0000"],
+          // Parent imports. Put `..` last.
+          ["^\\.\\.(?!/?$)", "^\\.\\./?$"],
+          // Other relative imports. Put same-folder imports and `.` last.
+          ["^\\./(?=.*/)(?!/?$)", "^\\.(?!/?$)", "^\\./?$"],
+          // Style imports.
+          ["^.+\\.?(css)$"]
+        ]
+      }
+    ],
+    "simple-import-sort/exports": "error",
   },
   settings: {
     react: {

--- a/components/DevBar/index.tsx
+++ b/components/DevBar/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-
 import cx from 'classnames';
+
 import styles from './DevBar.module.scss';
 
 const HIDDEN_DURATION = 8000;

--- a/components/GoogleParser/index.tsx
+++ b/components/GoogleParser/index.tsx
@@ -1,9 +1,9 @@
-import Link from 'next/link';
 import React from 'react';
-
 import cx from 'classnames';
-import styles from './GoogleParser.module.scss';
 import Image from 'next/image';
+import Link from 'next/link';
+
+import styles from './GoogleParser.module.scss';
 
 const LineBreakManager = ({ element }: any) => {
   // given a text string, replace all the /n with <br /> and return a jsx element

--- a/components/GuideImage/index.tsx
+++ b/components/GuideImage/index.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable @next/next/no-img-element */
 /* eslint-disable react/jsx-no-target-blank */
-import styles from './GuideImage.module.scss';
 import cx from 'classnames';
+
+import styles from './GuideImage.module.scss';
 
 type ImageSize = 'MICRO' | 'NARROW' | 'SMALL' | 'MEDIUM' | 'LARGE' | 'FULL';
 

--- a/components/GuideVideo/index.tsx
+++ b/components/GuideVideo/index.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/jsx-no-target-blank */
-import styles from './GuideVideo.module.scss';
 import cx from 'classnames';
+
+import styles from './GuideVideo.module.scss';
 
 const GuideVideo = ({ src }: { src: string }) => {
   return (

--- a/components/Modal/index.tsx
+++ b/components/Modal/index.tsx
@@ -1,12 +1,14 @@
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
-import styles from './Modal.module.scss';
-import { GuideLink } from '../GuideLink';
+
 import {
-  IElectronicsComponent,
   categoryObject,
   CategoryTags,
+  IElectronicsComponent,
 } from '../../pages/electronics-library';
+import { GuideLink } from '../GuideLink';
+
+import styles from './Modal.module.scss';
 interface ModalProps {
   show: boolean;
   closeModal: () => void;

--- a/components/Sidebar/index.tsx
+++ b/components/Sidebar/index.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import Router, { useRouter } from 'next/router';
 import ConfettiExplosion from 'react-confetti-explosion';
 import cx from 'classnames';
 import Image from 'next/image';
 import Link from 'next/link';
+import Router, { useRouter } from 'next/router';
 
 import { hasOwn, kebabToCamel } from '../../utils/format';
 

--- a/components/Sidebar/index.tsx
+++ b/components/Sidebar/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import Router, { useRouter } from 'next/router';
 import ConfettiExplosion from 'react-confetti-explosion';
 import cx from 'classnames';
 import Image from 'next/image';

--- a/components/Sidebar/index.tsx
+++ b/components/Sidebar/index.tsx
@@ -1,13 +1,12 @@
-import Link from 'next/link';
-import Router, { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
-
+import ConfettiExplosion from 'react-confetti-explosion';
 import cx from 'classnames';
-import styles from './Sidebar.module.scss';
 import Image from 'next/image';
+import Link from 'next/link';
+
 import { hasOwn, kebabToCamel } from '../../utils/format';
 
-import ConfettiExplosion from 'react-confetti-explosion';
+import styles from './Sidebar.module.scss';
 
 interface IPage {
   value: string;

--- a/components/WhatsDue/index.tsx
+++ b/components/WhatsDue/index.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
-import { PAGES_LAYOUT } from '../Sidebar';
-import styles from './WhatsDue.module.scss';
+import ConfettiExplosion from 'react-confetti-explosion';
 import cx from 'classnames';
 
-import ConfettiExplosion from 'react-confetti-explosion';
+import { PAGES_LAYOUT } from '../Sidebar';
+
+import styles from './WhatsDue.module.scss';
 
 export const WhatsDue = ({
   chapter,

--- a/components/Ws2812bLed/index.tsx
+++ b/components/Ws2812bLed/index.tsx
@@ -1,5 +1,6 @@
-import styles from './Ws2812bLed.module.scss';
 import cx from 'classnames';
+
+import styles from './Ws2812bLed.module.scss';
 
 export enum PIN {
   Vin = 'Vin',

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@supabase/supabase-js": "^1.35.6",
     "@supabase/ui": "^0.36.5",
     "classnames": "^2.3.1",
+    "eslint-plugin-simple-import-sort": "^10.0.0",
     "fast-fuzzy": "^1.12.0",
     "googleapis": "^107.0.0",
     "next": "12.2.5",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,19 +1,18 @@
 /* eslint-disable @next/next/no-page-custom-font */
 /* eslint-disable @next/next/next-script-for-ga */
 
+import cx from 'classnames';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 
-import cx from 'classnames';
+import { DevBar } from '../components/DevBar';
+import { PAGES_LAYOUT, SectionNavigation, Sidebar } from '../components/Sidebar';
+import { isDev } from '../lib/devHelper';
+import { kebabToCamel, splitPath } from '../utils/format';
+
 import '../styles/globals.scss';
 import sidebarStyles from '../components/Sidebar/Sidebar.module.scss';
-
-import { isDev } from '../lib/devHelper';
-
-import { PAGES_LAYOUT, SectionNavigation, Sidebar } from '../components/Sidebar';
-import { DevBar } from '../components/DevBar';
-import { kebabToCamel, splitPath } from '../utils/format';
 
 function MyApp({ Component, pageProps }: AppProps) {
   const color = new Date().getDay() + 1;

--- a/pages/casting-library.tsx
+++ b/pages/casting-library.tsx
@@ -1,10 +1,11 @@
 import { google } from 'googleapis';
+import Image from 'next/image';
+import Link from 'next/link';
+
 import GuideImage from '../components/GuideImage';
 import { GuideLink } from '../components/GuideLink';
 
 import styles from '../styles/CastingLibrary.module.scss';
-import Image from 'next/image';
-import Link from 'next/link';
 
 export async function getStaticProps() {
   const spreadsheetId = '1oy8CSaAVCUW85ui_FAuW0YxfaDJNwehxXqTTWuVQkZo';

--- a/pages/electronics-library.tsx
+++ b/pages/electronics-library.tsx
@@ -1,13 +1,14 @@
 /* eslint-disable @next/next/no-img-element */
+import { useEffect, useRef, useState } from 'react';
 import { Searcher } from 'fast-fuzzy';
+import { google } from 'googleapis';
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+
 import { GuideLink } from '../components/GuideLink';
-import { useState, useEffect, useRef } from 'react';
 import Modal from '../components/Modal';
-import { google } from 'googleapis';
+
 import styles from '../styles/Page.module.scss';
-import cx from 'classnames';
 
 export interface IElectronicsComponent {
   name: string;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,8 +1,8 @@
+import cx from 'classnames';
 import Image from 'next/image';
 import Link from 'next/link';
 
 import styles from '../styles/Home.module.scss';
-import cx from 'classnames';
 
 const Home = () => {
   return (

--- a/pages/toobers/assembly/customize.tsx
+++ b/pages/toobers/assembly/customize.tsx
@@ -1,10 +1,11 @@
 /* eslint-disable @next/next/no-img-element */
 import { useEffect, useState } from 'react';
+import cx from 'classnames';
+
+import GuideImage from '../../../components/GuideImage';
+import { GuideLink } from '../../../components/GuideLink';
 
 import styles from '../../../styles/Customize.module.scss';
-import cx from 'classnames';
-import { GuideLink } from '../../../components/GuideLink';
-import GuideImage from '../../../components/GuideImage';
 
 const getRgbValuesFromHex = (hex: string) => {
   const r = parseInt(hex.slice(1, 3), 16);

--- a/pages/toobers/assembly/glue.tsx
+++ b/pages/toobers/assembly/glue.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+
 import GuideImage from '../../../components/GuideImage';
 
 const Glue = () => {

--- a/pages/toobers/breadboarding/first-circuit.tsx
+++ b/pages/toobers/breadboarding/first-circuit.tsx
@@ -1,7 +1,8 @@
 import Link from 'next/link';
+
 import GuideImage from '../../../components/GuideImage';
 import { GuideLink } from '../../../components/GuideLink';
-import { Ws2812bLed, PIN } from '../../../components/Ws2812bLed';
+import { PIN, Ws2812bLed } from '../../../components/Ws2812bLed';
 
 const Page = () => {
   return (

--- a/pages/toobers/breadboarding/test-microcontroller.tsx
+++ b/pages/toobers/breadboarding/test-microcontroller.tsx
@@ -1,7 +1,8 @@
 import Image from 'next/image';
+
 import GuideImage from '../../../components/GuideImage';
-import GuideVideo from '../../../components/GuideVideo';
 import { GuideLink } from '../../../components/GuideLink';
+import GuideVideo from '../../../components/GuideVideo';
 
 const Test = () => {
   return (

--- a/pages/toobers/cad/intro.tsx
+++ b/pages/toobers/cad/intro.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+
 import { GuideLink } from '../../../components/GuideLink';
 import { WhatsDue } from '../../../components/WhatsDue';
 

--- a/pages/toobers/intro/components-inside.tsx
+++ b/pages/toobers/intro/components-inside.tsx
@@ -1,5 +1,6 @@
-import Link from 'next/link';
 import { useEffect } from 'react';
+import Link from 'next/link';
+
 import GuideImage from '../../../components/GuideImage';
 
 const Page = () => {

--- a/pages/toobers/intro/install.tsx
+++ b/pages/toobers/intro/install.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
-
 import cx from 'classnames';
-import styles from './Toggle.module.scss';
+
 import GuideImage from '../../../components/GuideImage';
 import { WhatsDue } from '../../../components/WhatsDue';
+
+import styles from './Toggle.module.scss';
 
 const PageToggle = ({
   options,

--- a/pages/toobers/soldering/overview.tsx
+++ b/pages/toobers/soldering/overview.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+
 import GuideImage from '../../../components/GuideImage';
 import { GuideLink } from '../../../components/GuideLink';
 import { WhatsDue } from '../../../components/WhatsDue';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1189,6 +1189,11 @@ eslint-plugin-react@^7.29.4:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.7"
 
+eslint-plugin-simple-import-sort@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-10.0.0.tgz#cc4ceaa81ba73252427062705b64321946f61351"
+  integrity sha512-AeTvO9UCMSNzIHRkg8S6c3RPy5YEwKWSQPx3DYghLedo2ZQxowPFLGDN1AZ2evfg6r6mjBSZSLxLFsWSu3acsw==
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"


### PR DESCRIPTION
Hello! This PR was mostly me experimenting with eslint in automatically sorting/organizing imports. The rules I've selected order the imports based on 'group' from most global to least global to finally just CSS and SCSS styles. 

Shouldn't be much to approve for this one, but just taking a quick look for visibility and we'll probably want something similar in our monorepo eventually.